### PR TITLE
Suggested fixes/enhancements

### DIFF
--- a/DS1307RTC.cpp
+++ b/DS1307RTC.cpp
@@ -22,7 +22,13 @@
   5 Sep 2011 updated for Arduino 1.0
  */
 
+
+#if defined (__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || (__AVR_ATtiny2313__)
+#include <TinyWireM.h>
+#define Wire TinyWireM
+#else
 #include <Wire.h>
+#endif
 #include "DS1307RTC.h"
 
 #define DS1307_CTRL_ID 0x68 
@@ -44,10 +50,7 @@ bool DS1307RTC::set(time_t t)
 {
   tmElements_t tm;
   breakTime(t, tm);
-  tm.Second |= 0x80;  // stop the clock 
-  write(tm); 
-  tm.Second &= 0x7f;  // start the clock
-  write(tm); 
+  return write(tm); 
 }
 
 // Aquire data from the RTC chip in BCD format
@@ -94,10 +97,13 @@ bool DS1307RTC::read(tmElements_t &tm)
 
 bool DS1307RTC::write(tmElements_t &tm)
 {
+  // To eliminate any potential race conditions,
+  // stop the clock before writing the values,
+  // then restart it after.
   Wire.beginTransmission(DS1307_CTRL_ID);
 #if ARDUINO >= 100  
   Wire.write((uint8_t)0x00); // reset register pointer  
-  Wire.write(dec2bcd(tm.Second)) ;   
+  Wire.write((uint8_t)0x80); // Stop the clock. The seconds will be written last
   Wire.write(dec2bcd(tm.Minute));
   Wire.write(dec2bcd(tm.Hour));      // sets 24 hour format
   Wire.write(dec2bcd(tm.Wday));   
@@ -106,7 +112,7 @@ bool DS1307RTC::write(tmElements_t &tm)
   Wire.write(dec2bcd(tmYearToY2k(tm.Year))); 
 #else  
   Wire.send(0x00); // reset register pointer  
-  Wire.send(dec2bcd(tm.Second)) ;   
+  Wire.send(0x80); // Stop the clock. The seconds will be written last
   Wire.send(dec2bcd(tm.Minute));
   Wire.send(dec2bcd(tm.Hour));      // sets 24 hour format
   Wire.send(dec2bcd(tm.Wday));   
@@ -119,7 +125,77 @@ bool DS1307RTC::write(tmElements_t &tm)
     return false;
   }
   exists = true;
+
+  // Now go back and set the seconds, starting the clock back up as a side effect
+  Wire.beginTransmission(DS1307_CTRL_ID);
+#if ARDUINO >= 100  
+  Wire.write((uint8_t)0x00); // reset register pointer  
+  Wire.write(dec2bcd(tm.Second)); // write the seconds, with the stop bit clear to restart
+#else  
+  Wire.send(0x00); // reset register pointer  
+  Wire.send(dec2bcd(tm.Second)); // write the seconds, with the stop bit clear to restart
+#endif
+  if (Wire.endTransmission() != 0) {
+    exists = false;
+    return false;
+  }
+  exists = true;
   return true;
+}
+
+unsigned char DS1307RTC::isRunning()
+{
+  Wire.beginTransmission(DS1307_CTRL_ID);
+#if ARDUINO >= 100  
+  Wire.write((uint8_t)0x00); 
+#else
+  Wire.send(0x00);
+#endif  
+  Wire.endTransmission();
+
+  // Just fetch the seconds register and check the top bit
+  Wire.requestFrom(DS1307_CTRL_ID, 1);
+#if ARDUINO >= 100
+  return !(Wire.read() & 0x80);
+#else
+  return !(Wire.receive() & 0x80);
+#endif  
+}
+
+void DS1307RTC::setCalibration(char calValue)
+{
+  unsigned char calReg = abs(calValue) & 0x1f;
+  if (calValue >= 0) calReg |= 0x20; // S bit is positive to speed up the clock
+  Wire.beginTransmission(DS1307_CTRL_ID);
+#if ARDUINO >= 100  
+  Wire.write((uint8_t)0x07); // Point to calibration register
+  Wire.write(calReg);
+#else  
+  Wire.send(0x07); // Point to calibration register
+  Wire.send(calReg);
+#endif
+  Wire.endTransmission();  
+}
+
+char DS1307RTC::getCalibration()
+{
+  Wire.beginTransmission(DS1307_CTRL_ID);
+#if ARDUINO >= 100  
+  Wire.write((uint8_t)0x07); 
+#else
+  Wire.send(0x07);
+#endif  
+  Wire.endTransmission();
+
+  Wire.requestFrom(DS1307_CTRL_ID, 1);
+#if ARDUINO >= 100
+  unsigned char calReg = Wire.read();
+#else
+  unsigned char calReg = Wire.receive();
+#endif
+  char out = calReg & 0x1f;
+  if (!(calReg & 0x20)) out = -out; // S bit clear means a negative value
+  return out;
 }
 
 // PRIVATE FUNCTIONS

--- a/DS1307RTC.h
+++ b/DS1307RTC.h
@@ -19,6 +19,9 @@ class DS1307RTC
     static bool read(tmElements_t &tm);
     static bool write(tmElements_t &tm);
     static bool chipPresent() { return exists; }
+    static unsigned char isRunning();
+    static void setCalibration(char calValue);
+    static char getCalibration();
 
   private:
     static bool exists;


### PR DESCRIPTION
1. Add support for TinyWire on ATTiny platforms
2. Redo the write method to properly stop the clock before writing the time values, and write the seconds last.
3. Add support for the Pericom PT7C4311WEX calibration register.