### PR TITLE
Write weekday to RTC

### DIFF
--- a/examples/SetTime/SetTime.ino
+++ b/examples/SetTime/SetTime.ino
@@ -1,4 +1,3 @@
-#include <Wire.h>
 #include <TimeLib.h>
 #include <DS1307RTC.h>
 
@@ -70,6 +69,14 @@ bool getDate(const char *str)
   tm.Day = Day;
   tm.Month = monthIndex + 1;
   tm.Year = CalendarYrToTm(Year);
+  // Calculate week day lazily
+  // We make use of makeTime to get the epoch time
+  // and return from epoch with breakTime,
+  // which yields the week day
+  tm.Wday = 0;
+  time_t time_epoch = makeTime(tm);
+  breakTime(time_epoch, tm);
+  if (tm.Wday == 0) return false;
   return true;
 }
 


### PR DESCRIPTION
Currently, weekday register is not being written on. So it gets the default value 0 if date & time loaded with `SetTime.ino`

With this change, weekday is calculated and written to `tm`, which is then uploaded to the RTC.