### PR TITLE
User controlled wire begin

### DIFF
--- a/DS1307RTC.cpp
+++ b/DS1307RTC.cpp
@@ -35,7 +35,9 @@
 
 DS1307RTC::DS1307RTC()
 {
+  #ifndef DS1307_NO_WIRE
   Wire.begin();
+  #endif
 }
   
 // PUBLIC FUNCTIONS

--- a/DS1307RTC.cpp
+++ b/DS1307RTC.cpp
@@ -35,9 +35,6 @@
 
 DS1307RTC::DS1307RTC()
 {
-  #ifndef DS1307_NO_WIRE
-  Wire.begin();
-  #endif
 }
   
 // PUBLIC FUNCTIONS

--- a/DS1307RTC.h
+++ b/DS1307RTC.h
@@ -33,12 +33,6 @@ class DS1307RTC
 #undef RTC // workaround for Arduino Due, which defines "RTC"...
 #endif
 
-// Add Wire.begin to the header file so that user's may specify DS1307_NO_WIRE to do their own Wire.begin call
-#ifndef DS1307_NO_WIRE
-  Wire.begin();
-  #define DS1307_NO_WIRE
-#endif
-
 extern DS1307RTC RTC;
 
 #endif

--- a/DS1307RTC.h
+++ b/DS1307RTC.h
@@ -33,6 +33,12 @@ class DS1307RTC
 #undef RTC // workaround for Arduino Due, which defines "RTC"...
 #endif
 
+// Add Wire.begin to the header file so that user's may specify DS1307_NO_WIRE to do their own Wire.begin call
+#ifndef DS1307_NO_WIRE
+  Wire.begin();
+  #define DS1307_NO_WIRE
+#endif
+
 extern DS1307RTC RTC;
 
 #endif

--- a/examples/ReadTest/ReadTest.ino
+++ b/examples/ReadTest/ReadTest.ino
@@ -3,6 +3,7 @@
 #include <DS1307RTC.h>
 
 void setup() {
+  Wire.begin(); // Start I2C
   Serial.begin(9600);
   while (!Serial) ; // wait for serial
   delay(200);

--- a/examples/SetTime/SetTime.ino
+++ b/examples/SetTime/SetTime.ino
@@ -10,6 +10,8 @@ const char *monthName[12] = {
 tmElements_t tm;
 
 void setup() {
+  Wire.begin(); // Start I2C
+
   bool parse=false;
   bool config=false;
 


### PR DESCRIPTION
I am using the ESP32 and couldn't use the default I2C pins, so had to specify my own. The `Wire.begin()` from the library was causing issues, not allowing me to read and write to the RTC. I don't think a suitable solution is possible that allows for easily toggling the Wire.begin on and off unless the library is reworked to stop making the `RTC` variable.

So, I think it would be better to remove this Wire.begin() call and instead call on the user to do so.
